### PR TITLE
chore: upgrade JVM target from 1.8 to 17

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,17 +34,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
     }
     packaging {
         resources {


### PR DESCRIPTION
## Что сделано
- Обновлен `compileOptions` с `VERSION_1_8` на `VERSION_17`
- Обновлен `kotlinOptions.jvmTarget` с `1.8` на `17`
- Удалён устаревший блок `composeOptions` (Compose Compiler Gradle Plugin уже подключён через `alias(libs.plugins.compose.compiler)`)

## Зачем
- Совместимость с Android Studio Hedgehog+
- Доступ к новым языковым фичам Kotlin
- Подготовка к AGP 9.0

## Чек-лист
- [x] Сборка проходит локально (`./gradlew build`)
- [x] Нет deprecation warnings

Closes #5
Closes #11