### PR TITLE
ci: add detekt code review to CI pipeline

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,4 @@
-name: Android CI
+﻿name: Android CI
 
 on:
   push:
@@ -7,9 +7,37 @@ on:
     branches: [ main, master, develop ]
 
 jobs:
-  build:
+  lint:
+    name: 🔍 Code Review (Detekt)
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+    
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    
+    - name: Run Detekt
+      run: ./gradlew detekt
+      continue-on-error: true
+    
+    - name: Upload Detekt Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: detekt-report
+        path: app/build/reports/detekt/detekt.html
+      if: always()
 
+  build:
+    name: 🛠 Build & Test
+    runs-on: ubuntu-latest
+    needs: lint
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Что сделано
- Добавлен отдельный job `lint` с запуском Detekt
- Detekt отчёт загружается как артефакт
- Build job теперь зависит от lint job
- `continue-on-error: true` для detekt (не блокирует сборку)

## Зачем
- Автоматический code review на каждый PR
- Единый стиль кода
- Раннее обнаружение потенциальных проблем

## Для локального запуска
```bash
./gradlew detekt
```

Отчёт откроется в: `app/build/reports/detekt/detekt.html`