### PR TITLE
feat: replace Toast with Snackbar

### DIFF
--- a/app/src/main/java/com/example/testbinlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/testbinlist/ui/MainActivity.kt
@@ -12,9 +12,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -27,6 +31,8 @@ import com.example.compose.TestBinlistTheme
 import com.example.testbinlist.ui.composeUi.HistoryScreen
 import com.example.testbinlist.ui.composeUi.SearchScreen
 import com.example.testbinlist.ui.navigation.TopLevelRoute
+import com.example.testbinlist.viewmodels.SearchViewModel
+import org.koin.androidx.compose.koinViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,7 +45,18 @@ class MainActivity : ComponentActivity() {
         setContent {
             TestBinlistTheme {
                 val navController = rememberNavController()
-                Scaffold(bottomBar = {
+                val snackbarHostState = remember { SnackbarHostState() }
+                val searchViewModel: SearchViewModel = koinViewModel()
+
+                LaunchedEffect(Unit) {
+                    searchViewModel.snackbarEvent.collect { message ->
+                        snackbarHostState.showSnackbar(message)
+                    }
+                }
+
+                Scaffold(
+                    snackbarHost = { SnackbarHost(snackbarHostState) },
+                    bottomBar = {
                     NavigationBar {
                         val navBackStackEntry by navController.currentBackStackEntryAsState()
                         val currentDestination = navBackStackEntry?.destination

--- a/app/src/main/java/com/example/testbinlist/ui/composeUi/SearchScreen.kt
+++ b/app/src/main/java/com/example/testbinlist/ui/composeUi/SearchScreen.kt
@@ -1,6 +1,5 @@
 package com.example.testbinlist.ui.composeUi
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -16,7 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
@@ -96,21 +95,13 @@ fun SearchScreen(viewModel: SearchViewModel = koinViewModel<SearchViewModel>()) 
 
             state.isLoading -> LoadingState()
             state.errorMessage != null -> {
-                ShowSingleToastEvent(state)
-                viewModel.userMessageShown()
+                // Errors now shown via Snackbar in MainActivity
             }
         }
 
     }
 }
 
-
-@Composable
-private fun ShowSingleToastEvent(state: SearchViewState) {
-    Toast.makeText(
-        LocalContext.current, state.errorMessage, Toast.LENGTH_SHORT
-    ).show()
-}
 
 
 class CreditCardVisualTransformation : VisualTransformation {

--- a/app/src/main/java/com/example/testbinlist/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/com/example/testbinlist/viewmodels/SearchViewModel.kt
@@ -6,8 +6,10 @@ import com.example.testbinlist.domain.CardInfo
 import com.example.testbinlist.domain.DataBaseRepository
 import com.example.testbinlist.domain.GetCardInfoUseCase
 import com.example.testbinlist.domain.SharingRepository
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
@@ -25,6 +27,9 @@ class SearchViewModel(
     )
     val stateFlow = _internalStorageFlow.asStateFlow()
 
+    private val _snackbarEvent = Channel<String>()
+    val snackbarEvent = _snackbarEvent.receiveAsFlow()
+
     fun fetchCardInfo(value: String) {
         viewModelScope.launch {
             _internalStorageFlow.update { it.copy(isLoading = true) }
@@ -36,10 +41,11 @@ class SearchViewModel(
                         it.copy(cardInfo = currentCardInfo, errorMessage = null)
                     }
                 } else {
-                    _internalStorageFlow.updateAndGet {
-                        it.copy(
-                            cardInfo = CardInfo(), errorMessage = errorMessage
-                        )
+                    viewModelScope.launch {
+                        _snackbarEvent.send(errorMessage ?: "Unknown error")
+                    }
+                    _internalStorageFlow.update {
+                        it.copy(cardInfo = CardInfo())
                     }
                 }
                 _internalStorageFlow.update { it.copy(isLoading = false) }
@@ -47,10 +53,6 @@ class SearchViewModel(
 
         }
 
-    }
-
-    fun userMessageShown() {
-        _internalStorageFlow.value = _internalStorageFlow.value.copy(errorMessage = null)
     }
 
     fun openSite(value: String) {


### PR DESCRIPTION
## Что сделано
- Добавлен `SnackbarHost` в корневой `Scaffold` (MainActivity)
- `SearchViewModel` теперь отправляет ошибки через `Channel<String>`
- `MainActivity` собирает события через `LaunchedEffect` и показывает `Snackbar`
- Удалён `Toast.makeText()` из `SearchScreen`
- Удалён метод `userMessageShown()` из ViewModel

## Почему это лучше
- ✅ Нет side effects внутри `@Composable`
- ✅ Соответствует Material Design 3
- ✅ Проще тестировать (Channel можно замокать)
- ✅ Snackbar поддерживает action (например, Retry)

## Код
```kotlin
// ViewModel
private val _snackbarEvent = Channel<String>()
val snackbarEvent = _snackbarEvent.receiveAsFlow()

// UI
LaunchedEffect(Unit) {
    viewModel.snackbarEvent.collect { message ->
        snackbarHostState.showSnackbar(message)
    }
}
```

Closes #7