### PR TITLE
Fix critical bugs: ViewModel scoping, side-effects, repository API

### DIFF
--- a/app/src/main/java/com/example/testbinlist/data/DataBaseRepositoryImpl.kt
+++ b/app/src/main/java/com/example/testbinlist/data/DataBaseRepositoryImpl.kt
@@ -9,15 +9,18 @@ import com.example.testbinlist.domain.CardInfo
 import com.example.testbinlist.domain.Country
 import com.example.testbinlist.domain.DataBaseRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 
 class DataBaseRepositoryImpl(private val database: BinListAppDatabase) : DataBaseRepository {
-    override suspend fun getHistory(): Flow<List<CardInfo>> = flow {
-        val data = mutableListOf<CardInfo>()
-        database.cardDao().getAll().map { cardDb ->
-            val bankDb = database.bankDao().findBankByName(cardDb.bankName)
-            val countryDb = database.countryDao().findCountryByName(cardDb.countryName)
-            data.add(cardDb.toCardInfo(bankDb ?: BankDb("", "", "", ""), countryDb))
+    override fun getHistory(): Flow<List<CardInfo>> = flow {
+        val cards = database.cardDao().getAll()
+        val bankMap = database.bankDao().getAll().first().associateBy { it.name }
+        val countryMap = database.countryDao().getAll().first().associateBy { it.name }
+        val data = cards.map { cardDb ->
+            val bankDb = bankMap[cardDb.bankName] ?: BankDb("", "", "", "")
+            val countryDb = countryMap[cardDb.countryName] ?: CountryDb("", 0, 0)
+            cardDb.toCardInfo(bankDb, countryDb)
         }
         emit(data)
     }

--- a/app/src/main/java/com/example/testbinlist/domain/DataBaseRepository.kt
+++ b/app/src/main/java/com/example/testbinlist/domain/DataBaseRepository.kt
@@ -3,6 +3,6 @@ package com.example.testbinlist.domain
 import kotlinx.coroutines.flow.Flow
 
 interface DataBaseRepository {
-    suspend fun getHistory(): Flow<List<CardInfo>>
+    fun getHistory(): Flow<List<CardInfo>>
     suspend fun putCardIntoDb(cardInfo: CardInfo)
 }

--- a/app/src/main/java/com/example/testbinlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/testbinlist/ui/MainActivity.kt
@@ -91,7 +91,7 @@ class MainActivity : ComponentActivity() {
                     NavHost(
                         navController, startDestination = "search", Modifier.padding(innerPadding)
                     ) {
-                        composable("search") { SearchScreen() }
+                        composable("search") { SearchScreen(viewModel = searchViewModel) }
                         composable("history") { HistoryScreen(triggerHistory = true) }
                     }
                 }
@@ -101,8 +101,4 @@ class MainActivity : ComponentActivity() {
 }
 
 
-@Preview
-@Composable
-private fun BankInfoCardPreview() {
-    SearchScreen()
-}
+

--- a/app/src/main/java/com/example/testbinlist/ui/composeUi/HistoryScreen.kt
+++ b/app/src/main/java/com/example/testbinlist/ui/composeUi/HistoryScreen.kt
@@ -7,10 +7,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.testbinlist.viewmodels.HistoryViewModel
@@ -36,14 +35,13 @@ fun HistoryScreen(
             }
         }
     }
+    LaunchedEffect(triggerHistory) {
+        if (triggerHistory) {
+            viewModel.fetchHistory()
+        }
+    }
     Column {
         val state by viewModel.stateFlow.collectAsState()
-        var trigger = triggerHistory
-        val restoreHistory by remember { mutableStateOf(trigger) }
-        if (restoreHistory) {
-            viewModel.fetchHistory()
-            trigger = false
-        }
         SimpleToolBar("История")
         LazyColumn(
             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/example/testbinlist/ui/composeUi/SearchScreen.kt
+++ b/app/src/main/java/com/example/testbinlist/ui/composeUi/SearchScreen.kt
@@ -27,11 +27,8 @@ import androidx.compose.ui.unit.dp
 import com.example.testbinlist.domain.CardInfo
 import com.example.testbinlist.viewmodels.SearchViewModel
 import com.example.testbinlist.viewmodels.SearchViewState
-import org.koin.androidx.compose.koinViewModel
-
-
 @Composable
-fun SearchScreen(viewModel: SearchViewModel = koinViewModel<SearchViewModel>()) {
+fun SearchScreen(viewModel: SearchViewModel) {
     val onElementClickListener = OnElementClickListener { cardElement ->
         when (cardElement) {
             is CardElement.Site -> {
@@ -147,46 +144,3 @@ fun creditCardFilter(text: AnnotatedString): TransformedText {
 }
 
 
-@Preview
-@Composable
-fun SearchScreenPreview() {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp)
-            .padding(top = 48.dp, bottom = 12.dp, start = 12.dp, end = 12.dp)
-    ) {
-        val creditCardText = remember { mutableStateOf(TextFieldValue("")) }
-        val maxCharCreditCard = 8
-        // this for entering number only
-        val numberRegex = "^[0-9]+\$".toRegex()
-
-        OutlinedTextField(
-            isError = creditCardText.value.text.length < 6,
-            modifier = Modifier.width(300.dp),
-            value = creditCardText.value,
-            label = { Text("Номер карты") },
-            placeholder = { Text(text = "Введите от 6 до 8 знаков") },
-            onValueChange = { newValue ->
-                val text = newValue.text
-                if ((text.length <= maxCharCreditCard && numberRegex.matches(text)) or (text.isEmpty())) {
-                    creditCardText.value = newValue
-                }
-            },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            maxLines = 1,
-            visualTransformation = CreditCardVisualTransformation()
-        )
-        Button(modifier = Modifier.padding(
-            top = 12.dp,
-            bottom = 12.dp,
-            start = 12.dp,
-            end = 12.dp
-        ),
-            onClick = {},
-            content = { Text("Получить информацию") })
-        BankInfoCard(CardInfo(), onElementClickListener = OnElementClickListener { })
-    }
-
-}

--- a/app/src/main/java/com/example/testbinlist/viewmodels/SearchViewModel.kt
+++ b/app/src/main/java/com/example/testbinlist/viewmodels/SearchViewModel.kt
@@ -36,9 +36,7 @@ class SearchViewModel(
 
         when (validation) {
             is BinValidator.ValidationResult.Error -> {
-                viewModelScope.launch {
-                    _snackbarEvent.send(validation.message)
-                }
+                _snackbarEvent.trySend(validation.message)
                 return
             }
             is BinValidator.ValidationResult.Success -> {
@@ -56,9 +54,7 @@ class SearchViewModel(
                         it.copy(cardInfo = currentCardInfo, errorMessage = null)
                     }
                 } else {
-                    viewModelScope.launch {
-                        _snackbarEvent.send(errorMessage ?: "Unknown error")
-                    }
+                    _snackbarEvent.trySend(errorMessage ?: "Unknown error")
                     _internalStorageFlow.update {
                         it.copy(cardInfo = CardInfo())
                     }


### PR DESCRIPTION
Closes #21

- Pass shared SearchViewModel from MainActivity to SearchScreen to fix instance mismatch
- Replace composition side-effect in HistoryScreen with LaunchedEffect
- Remove suspend modifier from Flow-returning getHistory() (anti-pattern)
- Optimize Room N+1 queries with batch lookups via associateBy
- Remove redundant nested launches in SearchViewModel, use trySend